### PR TITLE
Lowered timeout time for smoother transitions

### DIFF
--- a/client/components/CountryPage.jsx
+++ b/client/components/CountryPage.jsx
@@ -54,7 +54,7 @@ class CountryPage extends React.Component {
           .then(() => {
             setTimeout(() => {
               this.props.countryPageReady()
-            }, 2500)
+            }, 700)
           })
       })
   }

--- a/client/reducers/waiting.js
+++ b/client/reducers/waiting.js
@@ -1,4 +1,4 @@
-import { GET_BACKGROUND_PENDING, GET_BACKGROUND_SUCCESS } from '../actions/getCountryBackground'
+import { GET_BACKGROUND_PENDING } from '../actions/getCountryBackground'
 import { COUNTRY_PAGE_READY } from '../actions/countryPageLoaded'
 
 export default function (state = false, action) {


### PR DESCRIPTION
Talked the db function over with Bryce and we basically came to the conclusion that the problem lies with the way images are loaded onto your screen through network calls. The store state is updated completely fine with the correct url but your DOM seems to have its own waiting indicator where it loads an image as white until it's fully loaded. This results in the appropriate actions being fired from the parent (home) component because its requirements are seemingly met and the sloppy UX where the user sees the bucket list prior to the country image properly loading.

Basically the only actual change in the code was to lower the timeout interval from 2500ms to 700ms so the transition looks a little smoother. The average network request generally sorts itself out within 700ms so it seemed to be the best comprise between fast and slow loading images.

TL;DR: 
Network calls are weird and load the background image as something like '8UBD73M' when loading, then as 'https://generic-image.jpeg' once fully received.